### PR TITLE
Misc updates

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -79,17 +79,13 @@ function run() {
             }
             // Do nothing if its not their first contribution
             console.log('Checking if its the user\'s first contribution');
-            if (!context.payload.sender) {
-                throw new Error('Internal error, no sender provided by GitHub');
-            }
-            const sender = context.payload.sender.login;
             const issue = context.issue;
             let firstContribution = false;
             if (isIssue) {
-                firstContribution = yield isFirstIssue(client, sender, issue.number);
+                firstContribution = yield isFirstIssue(client, issue.number);
             }
             else {
-                firstContribution = yield isFirstOpenedOrMergedPR(client, sender, issue.number, context.payload.action === 'closed');
+                firstContribution = yield isFirstOpenedOrMergedPR(client, issue.number, context.payload.action === 'closed');
             }
             if (!firstContribution) {
                 console.log('Not the user\'s first contribution');
@@ -113,14 +109,15 @@ function run() {
         }
     });
 }
-function isFirstIssue(client, sender, curIssueNumber) {
+function isFirstIssue(client, curIssueNumber) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         // get the issue details
         const { status: getIssueStatus, data: issue } = yield client.rest.issues.get(Object.assign(Object.assign({}, github.context.repo), { issue_number: curIssueNumber }));
         if (getIssueStatus !== 200) {
             throw new Error(`Received unexpected API status code ${getIssueStatus}`);
         }
-        let query = `repo:${github.context.repo.owner}/${github.context.repo.repo} author:${sender} created:<=${issue.created_at} type:issue`;
+        let query = `repo:${github.context.repo.owner}/${github.context.repo.repo} author:${(_a = issue.user) === null || _a === void 0 ? void 0 : _a.login} created:<=${issue.created_at} type:issue`;
         const { status: searchStatus, data: searchResults } = yield client.rest.search.issuesAndPullRequests({ q: query });
         if (searchStatus !== 200) {
             throw new Error(`Received unexpected API status code ${searchStatus}`);
@@ -129,16 +126,16 @@ function isFirstIssue(client, sender, curIssueNumber) {
         return searchResults.total_count === 1;
     });
 }
-function isFirstOpenedOrMergedPR(client, sender, curPullNumber, closed) {
+function isFirstOpenedOrMergedPR(client, curPullNumber, closed) {
+    var _a;
     return __awaiter(this, void 0, void 0, function* () {
         // get the PR's details
         const { status: getPRStatus, data: pr } = yield client.rest.pulls.get(Object.assign(Object.assign({}, github.context.repo), { pull_number: curPullNumber }));
         if (getPRStatus !== 200) {
             throw new Error(`Received unexpected API status code ${status}`);
         }
-        let query = `repo:${github.context.repo.owner}/${github.context.repo.repo} type:pr author:${sender}`;
+        let query = `repo:${github.context.repo.owner}/${github.context.repo.repo} type:pr author:${(_a = pr.user) === null || _a === void 0 ? void 0 : _a.login}`;
         if (closed) {
-            let query = `repo:${github.context.repo.owner}/${github.context.repo.repo} type:pr author:${sender}`;
             if (!pr.merged)
                 return false;
             query += ` closed:<=${pr.closed_at} is:merged`;

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,6 +34,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
 const github = __importStar(require("@actions/github"));
+const plugin_retry_1 = require("@octokit/plugin-retry");
+const plugin_throttling_1 = require("@octokit/plugin-throttling");
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
         try {
@@ -44,7 +46,21 @@ function run() {
                 throw new Error('Action must have at least one of issue-message or pr-message set');
             }
             // Get client and context
-            const client = github.getOctokit(core.getInput('repo-token', { required: true }));
+            const client = github.getOctokit(core.getInput('repo-token', { required: true }), {
+                request: { retries: 5 },
+                throttle: {
+                    onSecondaryRateLimit: (retryAfter, options) => {
+                        console.warn(`Secondary rate limit reached for request ${options.method} ${options.url}.`, `Will retry in ${retryAfter} seconds.`);
+                        return true;
+                    },
+                    onRateLimit: (retryAfter, options, octokit, retryCount) => {
+                        console.warn(`Rate limit reached for request ${options.method} ${options.url}.`, `Will retry in ${retryAfter} seconds.`);
+                        if (retryCount < 3) {
+                            return true;
+                        }
+                    }
+                }
+            }, plugin_retry_1.retry, plugin_throttling_1.throttling);
             const context = github.context;
             // Do nothing if its not a pr or issue
             const isIssue = !!context.payload.issue;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "first-interaction-action",
-  "version": "1.1.1-zephyr-2",
+  "version": "1.1.1-zephyr-3",
   "description": "An action for greeting first time contributors.",
   "main": "lib/main.js",
   "scripts": {
@@ -27,7 +27,10 @@
   "homepage": "https://github.com/zephyrproject-rtos/first-interaction#readme",
   "dependencies": {
     "@actions/core": "^1.10.0",
-    "@actions/github": "^5.1.1"
+    "@actions/github": "^5.1.1",
+    "@octokit/core": "^4.2.0",
+    "@octokit/plugin-retry": "^4.1.3",
+    "@octokit/plugin-throttling": "^5.2.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.13",


### PR DESCRIPTION
- Add throttling/retry plugins to automatically retry when hitting secondary rate limits (will also retry in the unlikely event that main API rate limit is hit too)
- Fix issue causing bot to not greet a first time contributor on their first merged PR as the "context.payload.sender" is effectively set to the person who closed the PR, not the person who authored it.